### PR TITLE
Expose pkgsCuda12 via legacyPackages for downstream flakes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -180,6 +180,11 @@
 
         packages.default = self.packages.${system}.usb-image;
 
+        # Expose pkgsCuda12 for downstream flakes to access ComfyUI packages, models, and fetchers
+        legacyPackages = {
+          inherit pkgsCuda12;
+        };
+
         checks.pre-commit-check = pre-commit-check;
 
         apps.pytorch-container = {


### PR DESCRIPTION
Exports the CUDA 12 package set as legacyPackages.pkgsCuda12 to allow downstream flakes to access ComfyUI packages, models, and fetchers.

This provides a cleaner interface than exporting individual packages, as downstream projects can directly access pkgsCuda12.comfyuiPackages.comfyui and pkgsCuda12.comfyuiModels.* for their custom configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)