### PR TITLE
Playbook: VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ This repository includes devshells for various NVIDIA DGX Spark playbooks from h
 | [TRT-LLM](./playbooks/trt-llm/README.md)                            | TensorRT-LLM for optimised inference                            |       ✅        |                  |
 | [vLLM Container](./playbooks/vllm-container/README.md)              | Run vLLM inference server with Qwen2.5-Math-1.5B-Instruct model |       ✅        |                  |
 | [vLLM Nix](./playbooks/vllm-nix/README.md)                          | Run vLLM inference server natively (Nix native, no containers)  |       ✅        |                  |
+| [VS Code](./playbooks/vscode/README.md)                             | VS Code remote development on DGX Spark                         |       ✅        |                  |
 
 ¹ Pre-installed on DGX OS
 

--- a/flake.nix
+++ b/flake.nix
@@ -169,6 +169,7 @@
         devShells.nccl-two-sparks = pkgs.callPackage ./playbooks/nccl-two-sparks/shell.nix {
           inherit nixglhost;
         };
+        devShells.vscode = pkgs.callPackage ./playbooks/vscode/shell.nix { inherit nixglhost; };
 
         packages.cuda-debug = pkgs.callPackage ./packages/cuda-debug { };
         packages.dgx-dashboard = pkgs.callPackage ./packages/dgx-dashboard { };

--- a/playbooks/vscode/README.md
+++ b/playbooks/vscode/README.md
@@ -1,0 +1,72 @@
+# VS Code on DGX Spark
+
+Develop on the NVIDIA DGX Spark using Visual Studio Code, either natively or
+via Remote SSH from your local machine.
+
+## Quick Start
+
+```bash
+nix develop .#vscode
+```
+
+This provides an SSH-ready environment for connecting to your DGX Spark.
+
+## Option 1: Remote SSH (Recommended)
+
+Use VS Code on your local machine and connect to the DGX Spark over SSH. This
+gives you local editor performance with remote compute.
+
+### Prerequisites
+
+- VS Code installed on your local machine
+- SSH access to your DGX Spark
+- The
+  [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)
+  extension
+
+### Setup
+
+1. Install the **Remote - SSH** extension in VS Code.
+2. Open the Command Palette (`Ctrl+Shift+P`) and select
+   **Remote-SSH: Connect to Host**.
+3. Enter your DGX Spark hostname, e.g. `user@dgxspark.local`.
+4. VS Code will install its server component on the remote machine
+   automatically.
+
+Alternatively, connect from the command line:
+
+```bash
+code --remote ssh-remote+user@dgxspark.local .
+```
+
+## Option 2: Native Installation
+
+Install VS Code directly on the DGX Spark for local use with the desktop
+environment.
+
+### Steps
+
+1. Download the ARM64 `.deb` package from
+   [code.visualstudio.com/download](https://code.visualstudio.com/download).
+2. Install with `sudo dpkg -i <package>.deb`.
+3. Resolve any dependency issues with `sudo apt-get install -f`.
+4. Launch with `code`.
+
+> **Note:** A GUI desktop environment must be active on the DGX Spark for native
+> use. Verify with `echo $DISPLAY`.
+
+## Recommended Extensions
+
+- [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) --
+  connect to the DGX Spark from your local machine
+- [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) --
+  Python language support, debugging, and Jupyter notebooks
+- [NVIDIA Nsight](https://marketplace.visualstudio.com/items?itemName=nvidia.nsight-vscode-edition) --
+  CUDA debugging and profiling
+- [Nix IDE](https://marketplace.visualstudio.com/items?itemName=jnoortheen.nix-ide) --
+  Nix language support
+
+## References
+
+- [NVIDIA DGX Spark VS Code Instructions](https://build.nvidia.com/spark/vscode/instructions)
+- [VS Code Remote SSH Documentation](https://code.visualstudio.com/docs/remote/ssh)

--- a/playbooks/vscode/shell.nix
+++ b/playbooks/vscode/shell.nix
@@ -1,0 +1,22 @@
+{ mkShell
+, nixglhost
+, openssh
+, vscode
+}:
+
+mkShell {
+  packages = [
+    nixglhost
+    openssh
+    vscode
+  ];
+
+  shellHook = ''
+    echo "=== VS Code on DGX Spark Playbook ==="
+    echo "Instructions: https://build.nvidia.com/spark/vscode/instructions"
+    echo ""
+    echo "Use VS Code Remote SSH to connect to your DGX Spark."
+    echo "Install the Remote-SSH extension, then:"
+    echo "  code --remote ssh-remote+user@dgxspark.local ."
+  '';
+}


### PR DESCRIPTION
## Summary
- Add VS Code playbook with devShell providing SSH tooling for Remote SSH workflow
- Document native installation and Remote SSH setup with recommended extensions
- Register `devShells.vscode` in flake.nix

Closes #42

## Test plan
- [x] `nix develop .#vscode` enters shell with openssh and prints instructions
- [ ] `nix flake check` passes
- [x] Pre-commit hooks pass on all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)