### PR TITLE
Add nvtop to DGX Spark system packages

### DIFF
--- a/modules/dgx-spark.nix
+++ b/modules/dgx-spark.nix
@@ -101,5 +101,7 @@ in
     };
 
     hardware.nvidia-container-toolkit.enable = true;
+
+    environment.systemPackages = [ pkgs.nvtopPackages.nvidia ];
   };
 }


### PR DESCRIPTION
## Summary
- Adds `nvtopPackages.nvidia` to `environment.systemPackages` in the DGX Spark NixOS module for GPU monitoring

## Test plan
- [x] `nix flake check --no-build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)