### PR TITLE
flake: simplify by using flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,6 +38,24 @@
     },
     "flake-parts": {
       "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
         "nixpkgs-lib": [
           "nixified-ai",
           "nixpkgs"
@@ -57,7 +75,7 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "nixified-ai",
@@ -76,24 +94,6 @@
       "original": {
         "id": "flake-parts",
         "type": "indirect"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
       }
     },
     "gitignore": {
@@ -119,7 +119,7 @@
     },
     "hercules-ci-effects": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": [
           "nixified-ai",
           "nixpkgs"
@@ -161,7 +161,7 @@
     },
     "nixified-ai": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "hercules-ci-effects": "hercules-ci-effects",
         "nixpkgs": [
           "nixpkgs"
@@ -196,6 +196,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -221,26 +236,11 @@
     "root": {
       "inputs": {
         "disko": "disko",
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nix-gl-host": "nix-gl-host",
         "nixified-ai": "nixified-ai",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-parts.url = "github:hercules-ci/flake-parts";
     nix-gl-host = {
       url = "github:numtide/nix-gl-host";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -23,221 +23,231 @@
   };
 
   outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    , nix-gl-host
-    , pre-commit-hooks
-    , nixified-ai
-    , disko
-    ,
-    }:
+    {
+      self,
+      nixpkgs,
+      flake-parts,
+      nix-gl-host,
+      pre-commit-hooks,
+      nixified-ai,
+      disko,
+    }@inputs:
     let
       linux617Overlay = import ./overlays/linux-6.17.nix;
       fixesOverlay = import ./overlays/fixes.nix;
       comfyuiModelsOverlay = import ./overlays/comfyui-models.nix;
     in
-    nixpkgs.lib.recursiveUpdate
-      (nixpkgs.lib.recursiveUpdate
-        {
-          # Expose the DGX Spark module for other projects
-          nixosModules.dgx-spark = import ./modules/dgx-spark.nix;
-          nixosModules.dgx-dashboard = import ./modules/dgx-dashboard.nix;
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      flake = {
+        # Expose the DGX Spark module for other projects
+        nixosModules.dgx-spark = import ./modules/dgx-spark.nix;
+        nixosModules.dgx-dashboard = import ./modules/dgx-dashboard.nix;
 
-          overlays.fixes = fixesOverlay;
+        overlays.fixes = fixesOverlay;
 
-          templates.dgx-spark = {
-            path = ./templates/dgx-spark;
-            description = "NixOS configuration template for DGX Spark systems";
+        templates.dgx-spark = {
+          path = ./templates/dgx-spark;
+          description = "NixOS configuration template for DGX Spark systems";
+        };
+
+        nixosConfigurations.dgx-spark = nixpkgs.lib.nixosSystem {
+          system = "aarch64-linux";
+          modules = [
+            disko.nixosModules.disko
+            ./nixos-anywhere/disk-config.nix
+            ./nixos-anywhere/configuration.nix
+          ];
+        };
+      };
+      systems = [ "aarch64-linux" ];
+      perSystem =
+        { system, ... }:
+        let
+          commonConfig = {
+            allowUnfree = true;
+            allowUnsupportedSystem = true;
+            cudaSupport = true;
+            cudaCapabilities = [ "12.0" ]; # TODO: try 12.1
           };
 
-          nixosConfigurations.dgx-spark = nixpkgs.lib.nixosSystem {
-            system = "aarch64-linux";
-            modules = [
-              disko.nixosModules.disko
-              ./nixos-anywhere/disk-config.nix
-              ./nixos-anywhere/configuration.nix
+          pkgs = import nixpkgs {
+            inherit system;
+            config = commonConfig;
+            overlays = [
+              linux617Overlay
+              fixesOverlay
+              nixified-ai.overlays.comfyui
+              nixified-ai.overlays.models
+              nixified-ai.overlays.fetchers
+              comfyuiModelsOverlay
             ];
           };
-        }
-        (flake-utils.lib.eachSystem [ "aarch64-linux" ] (
-          system:
-          let
-            commonConfig = {
-              allowUnfree = true;
-              allowUnsupportedSystem = true;
-              cudaSupport = true;
-              cudaCapabilities = [ "12.0" ]; # TODO: try 12.1
-            };
 
-            pkgs = import nixpkgs {
-              inherit system;
-              config = commonConfig;
-              overlays = [
-                linux617Overlay
-                fixesOverlay
-                nixified-ai.overlays.comfyui
-                nixified-ai.overlays.models
-                nixified-ai.overlays.fetchers
-                comfyuiModelsOverlay
-              ];
-            };
+          pythonEnv = pkgs.python3.withPackages (
+            ps: with ps; [
+              torch
+            ]
+          );
 
-            pythonEnv = pkgs.python3.withPackages (
-              ps: with ps; [
-                torch
-              ]
-            );
+          pythonForKernelConfig = pkgs.python3.withPackages (ps: [ ps.pytest ]);
 
-            pythonForKernelConfig = pkgs.python3.withPackages (ps: [ ps.pytest ]);
+          nixglhost = nix-gl-host.packages.${system}.default;
 
-            nixglhost = nix-gl-host.packages.${system}.default;
-
-            pre-commit-check = pre-commit-hooks.lib.${system}.run {
-              src = ./.;
-              hooks = {
-                nixpkgs-fmt = {
-                  enable = true;
-                  excludes = [ "^kernel-configs/" ];
-                };
-                prettier = {
-                  enable = true;
-                  types_or = [ "markdown" ];
-                };
-                trailing-whitespace = {
-                  enable = true;
-                  entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/trailing-whitespace-fixer";
-                  excludes = [
-                    "^patches/"
-                    "^vendor/"
-                  ];
-                };
-                end-of-file-fixer = {
-                  enable = true;
-                  entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/end-of-file-fixer";
-                  excludes = [
-                    "^patches/"
-                    "^vendor/"
-                  ];
-                };
+          pre-commit-check = pre-commit-hooks.lib.${system}.run {
+            src = ./.;
+            hooks = {
+              nixpkgs-fmt = {
+                enable = true;
+                excludes = [ "^kernel-configs/" ];
+              };
+              prettier = {
+                enable = true;
+                types_or = [ "markdown" ];
+              };
+              trailing-whitespace = {
+                enable = true;
+                entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/trailing-whitespace-fixer";
+                excludes = [
+                  "^patches/"
+                  "^vendor/"
+                ];
+              };
+              end-of-file-fixer = {
+                enable = true;
+                entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/end-of-file-fixer";
+                excludes = [
+                  "^patches/"
+                  "^vendor/"
+                ];
               };
             };
-          in
-          {
-            # Dev shells
-            devShells.default = pkgs.mkShell {
-              packages = with pkgs; [
-                nixglhost
-                pre-commit
-                nixpkgs-fmt
-                prettier
-              ];
+          };
+        in
+        {
+          # Dev shells
+          devShells.default = pkgs.mkShell {
+            packages = with pkgs; [
+              nixglhost
+              pre-commit
+              nixpkgs-fmt
+              prettier
+            ];
 
-              shellHook = ''
-                ${pre-commit-check.shellHook}
-              '';
-            };
+            shellHook = ''
+              ${pre-commit-check.shellHook}
+            '';
+          };
 
-            devShells.cuda = pkgs.mkShell {
-              packages = with pkgs; [
-                nixglhost
-                cudaPackages.cuda_cuobjdump
-                cudaPackages.cuda_nvcc
-                cudaPackages.cuda-samples
-              ];
+          devShells.cuda = pkgs.mkShell {
+            packages = with pkgs; [
+              nixglhost
+              cudaPackages.cuda_cuobjdump
+              cudaPackages.cuda_nvcc
+              cudaPackages.cuda-samples
+            ];
 
-              # Add NVIDIA driver libraries to the environment
-              shellHook = ''
-                echo "CUDA samples available at: ${pkgs.cudaPackages.cuda-samples}/bin"
-                ${pre-commit-check.shellHook}
-              '';
-            };
+            # Add NVIDIA driver libraries to the environment
+            shellHook = ''
+              echo "CUDA samples available at: ${pkgs.cudaPackages.cuda-samples}/bin"
+              ${pre-commit-check.shellHook}
+            '';
+          };
 
-            devShells.torch = pkgs.mkShell {
-              packages = with pkgs; [
-                nixglhost
-                pythonEnv
-              ];
-            };
+          devShells.torch = pkgs.mkShell {
+            packages = with pkgs; [
+              nixglhost
+              pythonEnv
+            ];
+          };
 
-            devShells.llama-cpp = pkgs.mkShell {
-              packages = with pkgs; [
-                nixglhost
-                llama-cpp
-              ];
-            };
+          devShells.llama-cpp = pkgs.mkShell {
+            packages = with pkgs; [
+              nixglhost
+              llama-cpp
+            ];
+          };
 
-            devShells.comfyui = pkgs.callPackage ./playbooks/comfyui/shell.nix { inherit nixglhost; };
-            devShells.flux-dreambooth = pkgs.callPackage ./playbooks/flux-dreambooth/shell.nix { inherit nixglhost; };
-            devShells.multimodal-inference = pkgs.callPackage ./playbooks/multimodal-inference/shell.nix { inherit nixglhost; };
-            devShells.pytorch-finetune = pkgs.callPackage ./playbooks/pytorch-finetune/shell.nix { inherit nixglhost; };
-            devShells.pytorch-finetune-nix = pkgs.callPackage ./playbooks/pytorch-finetune-nix/shell.nix { inherit nixglhost; };
+          devShells.comfyui = pkgs.callPackage ./playbooks/comfyui/shell.nix { inherit nixglhost; };
+          devShells.flux-dreambooth = pkgs.callPackage ./playbooks/flux-dreambooth/shell.nix {
+            inherit nixglhost;
+          };
+          devShells.multimodal-inference = pkgs.callPackage ./playbooks/multimodal-inference/shell.nix {
+            inherit nixglhost;
+          };
+          devShells.pytorch-finetune = pkgs.callPackage ./playbooks/pytorch-finetune/shell.nix {
+            inherit nixglhost;
+          };
+          devShells.pytorch-finetune-nix = pkgs.callPackage ./playbooks/pytorch-finetune-nix/shell.nix {
+            inherit nixglhost;
+          };
 
-            devShells.vllm-container = pkgs.callPackage ./playbooks/vllm-container/shell.nix { inherit nixglhost; };
-            devShells.nvfp4 = pkgs.callPackage ./playbooks/nvfp4/shell.nix { inherit nixglhost; };
-            devShells.vllm-nix = pkgs.callPackage ./playbooks/vllm-nix/shell.nix { inherit nixglhost; };
-            devShells.speculative-decoding = pkgs.callPackage ./playbooks/speculative-decoding/shell.nix { inherit nixglhost; };
-            devShells.trt-llm = pkgs.callPackage ./playbooks/trt-llm/shell.nix { inherit nixglhost; };
-            devShells.nccl-two-sparks = pkgs.callPackage ./playbooks/nccl-two-sparks/shell.nix {
-              inherit nixglhost;
-            };
-            devShells.multi-agent-chatbot = pkgs.callPackage ./playbooks/multi-agent-chatbot/shell.nix { inherit nixglhost; };
-            devShells.openshell = pkgs.callPackage ./playbooks/openshell/shell.nix {
-              inherit nixglhost;
-              openshell = pkgs.callPackage ./packages/openshell { };
-            };
+          devShells.vllm-container = pkgs.callPackage ./playbooks/vllm-container/shell.nix {
+            inherit nixglhost;
+          };
+          devShells.nvfp4 = pkgs.callPackage ./playbooks/nvfp4/shell.nix { inherit nixglhost; };
+          devShells.vllm-nix = pkgs.callPackage ./playbooks/vllm-nix/shell.nix { inherit nixglhost; };
+          devShells.speculative-decoding = pkgs.callPackage ./playbooks/speculative-decoding/shell.nix {
+            inherit nixglhost;
+          };
+          devShells.trt-llm = pkgs.callPackage ./playbooks/trt-llm/shell.nix { inherit nixglhost; };
+          devShells.nccl-two-sparks = pkgs.callPackage ./playbooks/nccl-two-sparks/shell.nix {
+            inherit nixglhost;
+          };
+          devShells.multi-agent-chatbot = pkgs.callPackage ./playbooks/multi-agent-chatbot/shell.nix {
+            inherit nixglhost;
+          };
+          devShells.openshell = pkgs.callPackage ./playbooks/openshell/shell.nix {
+            inherit nixglhost;
+            openshell = pkgs.callPackage ./packages/openshell { };
+          };
 
-            packages.cuda-debug = pkgs.callPackage ./packages/cuda-debug { };
-            packages.dgx-dashboard = pkgs.callPackage ./packages/dgx-dashboard { };
-            packages.openshell = pkgs.callPackage ./packages/openshell { };
+          packages.cuda-debug = pkgs.callPackage ./packages/cuda-debug { };
+          packages.dgx-dashboard = pkgs.callPackage ./packages/dgx-dashboard { };
+          packages.openshell = pkgs.callPackage ./packages/openshell { };
 
-            # Expose pkgs for downstream flakes to access ComfyUI packages, models, and fetchers
-            legacyPackages = {
-              inherit pkgs;
-            };
+          # Expose pkgs for downstream flakes to access ComfyUI packages, models, and fetchers
+          legacyPackages = {
+            inherit pkgs;
+          };
 
-            checks = {
-              pre-commit-check = pre-commit-check;
+          checks = {
+            pre-commit-check = pre-commit-check;
 
-              kernel-config-tests = pkgs.runCommand "kernel-config-tests" { src = ./.; } ''
-                set -e
-                cd $src/tests
-                ${pythonForKernelConfig}/bin/python3 -m pytest test_generate_config.py -v
-                touch $out
-              '';
-            };
+            kernel-config-tests = pkgs.runCommand "kernel-config-tests" { src = ./.; } ''
+              set -e
+              cd $src/tests
+              ${pythonForKernelConfig}/bin/python3 -m pytest test_generate_config.py -v
+              touch $out
+            '';
+          };
 
-            # CI-buildable checks for devShells and nixosConfiguration
-            # Requires CUDA builders, so not included in checks (which run on GitHub Actions)
-            # Build locally with: nix build .#ciChecks.aarch64-linux
-            ciChecks = (nixpkgs.lib.mapAttrs'
-              (name: shell: nixpkgs.lib.nameValuePair "devShell-${name}" shell.inputDerivation)
-              self.devShells.${system}
-            )
+          # CI-buildable checks for devShells and nixosConfiguration
+          # Requires CUDA builders, so not included in checks (which run on GitHub Actions)
+          # Build locally with: nix build .#ciChecks.aarch64-linux
+          ciChecks =
+            (nixpkgs.lib.mapAttrs' (
+              name: shell: nixpkgs.lib.nameValuePair "devShell-${name}" shell.inputDerivation
+            ) self.devShells.${system})
             // {
               nixos-dgx-spark = self.nixosConfigurations.dgx-spark.config.system.build.toplevel;
             };
 
-            apps.pytorch-container = {
-              type = "app";
-              program = "${pkgs.writeShellScript "pytorch-container" ''
-            exec ${pkgs.podman}/bin/podman run --rm -it --device nvidia.com/gpu=all nvcr.io/nvidia/pytorch:25.11-py3 /bin/bash
-          ''}";
-              meta.description = "Run NVIDIA PyTorch container with GPU support";
-            };
+          apps.pytorch-container = {
+            type = "app";
+            program = "${pkgs.writeShellScript "pytorch-container" ''
+              exec ${pkgs.podman}/bin/podman run --rm -it --device nvidia.com/gpu=all nvcr.io/nvidia/pytorch:25.11-py3 /bin/bash
+            ''}";
+            meta.description = "Run NVIDIA PyTorch container with GPU support";
+          };
 
-            apps.generate-kernel-config = {
-              type = "app";
-              program = "${pkgs.writeShellScript "generate-kernel-config" ''
-            exec ${pythonForKernelConfig}/bin/python3 ${./scripts/generate-terse-dgx-config.py} "$@"
-          ''}";
-              meta.description = "Generate terse DGX kernel configuration";
-            };
-          }
-        )))
-      (flake-utils.lib.eachDefaultSystem (
-        system:
-        {
+          apps.generate-kernel-config = {
+            type = "app";
+            program = "${pkgs.writeShellScript "generate-kernel-config" ''
+              exec ${pythonForKernelConfig}/bin/python3 ${./scripts/generate-terse-dgx-config.py} "$@"
+            ''}";
+            meta.description = "Generate terse DGX kernel configuration";
+          };
+
           packages.usb-image =
             let
               targetSystem = "aarch64-linux";
@@ -266,6 +276,6 @@
             }).config.system.build.isoImage;
 
           packages.default = self.packages.${system}.usb-image;
-        }
-      ));
+        };
+    };
 }


### PR DESCRIPTION
The flake currently has two sections. 

- `perSystem` / `eachSystem` 
- `system` agnostic stuff, like `nixosModules` `templates`     

This is also handled much nicer by flake-parts. 