### PR TITLE
docs: align with technical writer best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 [![Cachix](https://img.shields.io/badge/cachix-graham33-blue.svg)](https://graham33.cachix.org)
 [![License](https://img.shields.io/github/license/graham33/nixos-dgx-spark)](LICENSE)
 
-Allows you to try DGX Spark Playbooks using Nix on DGX OS, and install NixOS
-on your DGX Spark for the full Nix experience! Provides USB images and a NixOS
-module to add settings required for DGX Spark systems.
+Try DGX Spark playbooks using Nix on DGX OS, or install NixOS on your DGX
+Spark for the full Nix experience. The repository provides USB images and a
+NixOS module with settings for DGX Spark systems.
 
-This works on the NVIDIA DGX Spark itself, and has also been reported to work
-on the Asus Ascent GX10.
+This works on the NVIDIA DGX Spark itself and also on the Asus Ascent GX10.
 
 See my 5 minute lightning talk from [Planet Nix](https://planetnix.com) for an intro:
  https://youtu.be/AvK_gi_snJE?si=MPKv3iiuS9B5elIE
@@ -60,8 +59,8 @@ nixglhost deviceQuery
 ## NixOS on the DGX Spark
 
 > [!WARNING]
-> Only DGX OS can boot from the factory firmware. You will need to
-> [update firmware](#firmware-updates) before trying to install NixOS.
+> Only DGX OS can boot from the factory firmware. You need to
+> [update firmware](#firmware-updates) before installing NixOS.
 
 ### USB Boot Image
 
@@ -75,20 +74,20 @@ sync
 
 The image includes two kernel options, selectable from the GRUB boot menu:
 
-- **NixOS** (default) - NVIDIA's specialized kernel for DGX Spark with full GPU support and working Ethernet
+- **NixOS** (default) - NVIDIA's specialised kernel for DGX Spark with full GPU support and working Ethernet
 - **NixOS (standard-kernel)** - Standard NixOS 6.17 kernel (Ethernet has problems)
 
 #### Booting
 
 Disable Secure Boot in the DGX Spark BIOS and boot from the USB drive.
 
-You can then following the installation instructions in the NixOS manual: https://nixos.org/manual/nixos/stable/#sec-installation-manual
+You can then follow the installation instructions in the NixOS manual: https://nixos.org/manual/nixos/stable/#sec-installation-manual
 
 ### Using the DGX Spark module
 
 This module provides configurable DGX Spark hardware support with options for kernel selection.
 
-#### Module Configuration Options
+#### Module configuration options
 
 ```nix
 hardware.dgx-spark = {
@@ -97,18 +96,18 @@ hardware.dgx-spark = {
 };
 ```
 
-#### Using NVIDIA Kernel
+#### Using NVIDIA kernel
 
 ```nix
 hardware.dgx-spark.enable = true;  # Uses NVIDIA kernel by default
 ```
 
-The NVIDIA kernel is a custom build optimized for NVIDIA DGX Spark systems. The kernel configuration is generated from NVIDIA's Debian annotations and compared with NixOS defaults to produce a minimal, maintainable configuration.
+The NVIDIA kernel is a custom build optimised for NVIDIA DGX Spark systems. The kernel configuration is generated from NVIDIA's Debian annotations and compared with NixOS defaults to produce a minimal, maintainable configuration.
 
 The module also enables the DGX Dashboard web interface at
 <http://localhost:11000>, providing GPU telemetry and system monitoring.
 
-#### Using Standard NixOS Kernel (has some issues with networking)
+#### Using standard NixOS kernel (has some issues with networking)
 
 ```nix
 hardware.dgx-spark = {
@@ -117,7 +116,7 @@ hardware.dgx-spark = {
 };
 ```
 
-#### Kernel Configuration Management
+#### Kernel configuration management
 
 The kernel configuration is generated from NVIDIA's Debian annotations and stored in `kernel-configs/nvidia-dgx-spark-<version>.nix`. This terse configuration only contains options that differ from NixOS defaults, reducing verbosity by ~82%.
 
@@ -127,12 +126,12 @@ To regenerate the kernel configuration:
 nix run .#generate-kernel-config
 ```
 
-This will:
+This:
 
-1. Fetch the NVIDIA kernel source from GitHub
-2. Build the NixOS baseline kernel config
-3. Compare NVIDIA's annotations with NixOS defaults
-4. Generate a terse config file with only the differences
+1. Fetches the NVIDIA kernel source from GitHub
+2. Builds the NixOS baseline kernel config
+3. Compares NVIDIA's annotations with NixOS defaults
+4. Generates a terse config file with only the differences
 
 Regeneration is needed when:
 
@@ -145,7 +144,7 @@ You can also use a local kernel source for development:
 nix run .#generate-kernel-config -- --kernel-source /path/to/NV-Kernels
 ```
 
-#### Importing in Other Projects
+#### Importing in other projects
 
 Other projects can import this flake and use the DGX Spark module:
 
@@ -169,7 +168,7 @@ Other projects can import this flake and use the DGX Spark module:
 }
 ```
 
-### Quick Start NixOS Template
+### Quick start NixOS template
 
 For a complete NixOS configuration template specifically designed for DGX Spark
 systems, you can use the template:
@@ -179,19 +178,19 @@ systems, you can use the template:
 mkdir my-dgx-spark-config
 cd my-dgx-spark-config
 
-# Initialize with the DGX Spark template
+# Initialise with the DGX Spark template
 nix flake init -t github:graham33/nixos-dgx-spark#dgx-spark
 ```
 
-This will create a complete NixOS configuration with:
+This creates a complete NixOS configuration with:
 
 - `flake.nix` - Flake configuration that imports the DGX Spark module
-- `configuration.nix` - Main system configuration optimized for DGX Spark
+- `configuration.nix` - Main system configuration optimised for DGX Spark
 - `hardware-configuration.nix` - Hardware configuration template
 
-#### Customizing the Template
+#### Customising the template
 
-After initializing the template, you'll need to:
+After initialising the template, you need to:
 
 1. **Generate hardware configuration and update template:**
 
@@ -204,7 +203,7 @@ After initializing the template, you'll need to:
    # values from /tmp/nixos-config/hardware-configuration.nix
    ```
 
-2. **Edit `configuration.nix` to customize:**
+2. **Edit `configuration.nix` to customise:**
    - Change hostname from `dgx-spark` to your preferred name
    - Update username from `nixos` to your preferred username
    - Add your SSH public keys for remote access
@@ -221,11 +220,11 @@ After initializing the template, you'll need to:
    sudo nixos-rebuild switch --flake /etc/nixos#dgx-spark
    ```
 
-### Firmware Updates
+### Firmware updates
 
 As [noted](https://github.com/graham33/nixos-dgx-spark/issues/32#issuecomment-4182117621)
 in #32, only DGX OS can boot from the factory firmware. If NixOS can't boot
-from the factory firmware, you will need to update firmware from DGX OS first.
+from the factory firmware, you need to update firmware from DGX OS first.
 
 The module enables [fwupd](https://fwupd.org/) for firmware updates. NVIDIA
 publishes DGX Spark firmware to the Linux Vendor Firmware Service (LVFS). To
@@ -243,7 +242,7 @@ fwupdmgr update
 
 ## Playbooks
 
-This repository includes devshells for various NVIDIA DGX Spark playbooks from https://build.nvidia.com/spark:
+This repository includes devshells for NVIDIA DGX Spark playbooks from https://build.nvidia.com/spark:
 
 | Playbook                                                                | Description                                                     |        Type         | Tested on NixOS | Tested on DGX OS |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------- | :-----------------: | :-------------: | :--------------: |
@@ -296,7 +295,7 @@ useful for headless setups where you have SSH access to the target machine.
 nix run github:nix-community/nixos-anywhere -- --flake github:graham33/nixos-dgx-spark#dgx-spark root@<ip>
 ```
 
-This will partition the NVMe disk and install NixOS with the DGX Spark module
+This partitions the NVMe disk and installs NixOS with the DGX Spark module
 enabled. You may want to customise `nixos-anywhere/configuration.nix` (e.g. to
 add SSH keys or change the hostname) — clone the repo and point `--flake` at
 your local checkout instead.

--- a/playbooks/comfyui/README.md
+++ b/playbooks/comfyui/README.md
@@ -1,6 +1,6 @@
-# ComfyUI Playbook
+# ComfyUI playbook
 
-This playbook provides a Nix devshell for running ComfyUI with NVIDIA GPU support and the Stable Diffusion 1.5 model pre-installed.
+Run ComfyUI with NVIDIA GPU support and Stable Diffusion 1.5 pre-installed via a Nix devshell.
 
 ## Quick Start
 
@@ -18,7 +18,7 @@ This playbook provides a Nix devshell for running ComfyUI with NVIDIA GPU suppor
 
 3. Access the web interface at `http://<IP>:8188`
 
-## Pre-installed Models
+## Pre-installed models
 
 - **Stable Diffusion 1.5** (fp16, ~2GB) - General-purpose image generation
 

--- a/playbooks/connect-two-sparks/README.md
+++ b/playbooks/connect-two-sparks/README.md
@@ -1,4 +1,4 @@
-# Connect Two Sparks Playbook
+# Connect two Sparks playbook
 
 Configure network connectivity between two NVIDIA DGX Spark units via a
 200GbE QSFP direct connection for distributed workloads.
@@ -14,7 +14,7 @@ Configure network connectivity between two NVIDIA DGX Spark units via a
 nix develop .#connect-two-sparks
 ```
 
-### Verify Physical Connection
+### Verify physical connection
 
 After connecting the QSFP cable, check that the interface is up:
 
@@ -25,7 +25,7 @@ ibdev2netdev
 Look for interfaces showing `(Up)` status, typically `enp1s0f0np0` or
 `enp1s0f1np1`.
 
-### Network Configuration
+### Network configuration
 
 Assign static IPs on each Spark:
 
@@ -39,14 +39,14 @@ sudo ip addr add 192.168.100.11/24 dev enp1s0f1np1
 sudo ip link set enp1s0f1np1 up
 ```
 
-### SSH Setup
+### SSH setup
 
 ```bash
 ssh-keygen -t ed25519
 ssh-copy-id user@192.168.100.11
 ```
 
-### Network Testing
+### Network testing
 
 ```bash
 # On Spark 1 (server)
@@ -56,7 +56,7 @@ iperf3 -s
 iperf3 -c 192.168.100.10
 ```
 
-> **Note:** Two DGX Spark units are required for this playbook.
+Two DGX Spark units are required for this playbook.
 
 ## References
 

--- a/playbooks/dgx-dashboard/README.md
+++ b/playbooks/dgx-dashboard/README.md
@@ -1,4 +1,4 @@
-# DGX Dashboard Playbook
+# DGX Dashboard playbook
 
 The DGX Dashboard is a web application that provides a graphical interface for
 GPU telemetry, resource monitoring, and an integrated JupyterLab environment.

--- a/playbooks/flux-dreambooth/README.md
+++ b/playbooks/flux-dreambooth/README.md
@@ -1,4 +1,4 @@
-# FLUX.1 Dreambooth LoRA Fine-tuning Playbook
+# FLUX.1 Dreambooth LoRA fine-tuning playbook
 
 Fine-tune the FLUX.1-dev 12B image generation model using Dreambooth LoRA on
 DGX Spark, then generate images with ComfyUI.
@@ -28,9 +28,9 @@ DGX Spark, then generate images with ComfyUI.
    flux-build-comfyui
    ```
 
-3. Download model weights (~30-45 minutes, one-time). Note: this writes to a
-   `flux-workspace` directory in your current working directory (override with
-   `export FLUX_WORKSPACE=/path/to/workspace`):
+3. Download model weights (~30-45 minutes, one-time). This writes to a
+   `flux-workspace` directory in your current working directory. Override
+   the location with `export FLUX_WORKSPACE=/path/to/workspace`:
 
    ```bash
    flux-download
@@ -53,7 +53,7 @@ DGX Spark, then generate images with ComfyUI.
 
    Open <http://localhost:8188> in your browser.
 
-## Available Commands
+## Available commands
 
 | Command              | Description                                               |
 | -------------------- | --------------------------------------------------------- |
@@ -64,7 +64,7 @@ DGX Spark, then generate images with ComfyUI.
 | `flux-comfyui`       | Launch ComfyUI for image generation                       |
 | `flux-pytorch-shell` | Drop into a bare PyTorch container with workspace mounted |
 
-## Workspace Layout
+## Workspace layout
 
 All data is stored under `$FLUX_WORKSPACE` (defaults to `$PWD/flux-workspace`):
 
@@ -80,7 +80,7 @@ flux-workspace/
   outputs/         # Generated images
 ```
 
-## Dataset Configuration
+## Dataset configuration
 
 Create `flux-workspace/flux_data/data.toml` to define your training concepts.
 Example:
@@ -103,7 +103,7 @@ keep_tokens = 1
 
 Place 5-10 images per concept in the corresponding subdirectory.
 
-## Memory Management
+## Memory management
 
 DGX Spark uses a Unified Memory Architecture (UMA). To free cached memory
 after stopping containers:

--- a/playbooks/multi-agent-chatbot/README.md
+++ b/playbooks/multi-agent-chatbot/README.md
@@ -1,4 +1,4 @@
-# Build and Deploy a Multi-Agent Chatbot Playbook
+# Build and deploy a multi-agent chatbot playbook
 
 Deploy a multi-agent chatbot system using LLM orchestration on the DGX Spark.
 
@@ -46,8 +46,8 @@ podman-compose -f docker-compose.yml -f docker-compose-models.yml down
 podman volume rm "$(basename "$PWD")_postgres_data"
 ```
 
-> **Note:** DGX Spark hardware with NVIDIA GPU is required. This demo uses
-> approximately 120 GB of the 128 GB available on a DGX Spark.
+DGX Spark hardware with an NVIDIA GPU is required. This demo uses
+approximately 120 GB of the 128 GB available on a DGX Spark.
 
 ## References
 

--- a/playbooks/multimodal-inference/README.md
+++ b/playbooks/multimodal-inference/README.md
@@ -1,4 +1,4 @@
-# Multi-modal Inference Playbook
+# Multi-modal inference playbook
 
 Run text-to-image inference models (Flux.1, SDXL) on the DGX Spark using NVIDIA's
 TensorRT Diffusion demos inside the PyTorch container.
@@ -31,7 +31,7 @@ TensorRT Diffusion demos inside the PyTorch container.
      --hf-token=$HF_TOKEN --bf16 --download-onnx-models
    ```
 
-## Supported Models
+## Supported models
 
 | Model          | Script                 | Notes                        |
 | -------------- | ---------------------- | ---------------------------- |
@@ -39,7 +39,7 @@ TensorRT Diffusion demos inside the PyTorch container.
 | Flux.1 Schnell | `demo_txt2img_flux.py` | `--version="flux.1-schnell"` |
 | SDXL (xl-1.0)  | `demo_txt2img_xl.py`   | `--version xl-1.0`           |
 
-> **Note:** FP16 Flux.1 Schnell requires more than 48 GB VRAM for native export.
+FP16 Flux.1 Schnell requires more than 48 GB VRAM for native export.
 
 ## References
 

--- a/playbooks/nccl-two-sparks/README.md
+++ b/playbooks/nccl-two-sparks/README.md
@@ -1,4 +1,4 @@
-# NCCL for Two Sparks Playbook
+# NCCL for two Sparks playbook
 
 Multi-node GPU communication using NVIDIA Collective Communications Library
 (NCCL) between two DGX Spark units with Blackwell architecture.
@@ -38,7 +38,7 @@ Multi-node GPU communication using NVIDIA Collective Communications Library
    nccl-run-16g <IP_Node1> <IP_Node2>
    ```
 
-## Available Commands
+## Available commands
 
 - `nccl-run <IP1> <IP2> [interface]` - Run all_gather_perf across two nodes
   (default interface: `enp1s0f1np1`)

--- a/playbooks/nvfp4/README.md
+++ b/playbooks/nvfp4/README.md
@@ -1,4 +1,4 @@
-# NVFP4 Quantisation Playbook
+# NVFP4 quantisation playbook
 
 NVFP4 quantisation reduces LLM model size with minimal quality loss,
 enabling larger models to fit in GPU memory on the DGX Spark.
@@ -14,9 +14,9 @@ nix develop .#nvfp4
 | Command                  | Description                                |
 | ------------------------ | ------------------------------------------ |
 | `nvfp4-start`            | Start an interactive container shell       |
-| `nvfp4-quantize [MODEL]` | Quantize a model to NVFP4 format           |
-| `nvfp4-validate`         | Check quantized model output files         |
-| `nvfp4-test [MODEL]`     | Test-load the quantized model              |
+| `nvfp4-quantize [MODEL]` | Quantise a model to NVFP4 format           |
+| `nvfp4-validate`         | Check quantised model output files         |
+| `nvfp4-test [MODEL]`     | Test-load the quantised model              |
 | `nvfp4-serve [MODEL]`    | Serve the model with OpenAI-compatible API |
 | `nvfp4-chat [PROMPT]`    | Send a chat request to the running server  |
 | `nvfp4-cleanup`          | Remove output models and cached data       |
@@ -55,11 +55,11 @@ nvfp4-chat "What is artificial intelligence?"
 NVFP4 (NVIDIA FP4) is a 4-bit floating-point quantisation format that:
 
 - Reduces model memory ~3.5x compared to FP16 and ~1.8x compared to FP8
-- Maintains near-original model quality (typically less than 1% degradation)
+- Maintains near-original model quality (less than 1% degradation in most benchmarks)
 - Leverages Blackwell GPU hardware support for native FP4 computation
 
-> **Note:** DGX Spark hardware with NVIDIA GPU is required for GPU-accelerated
-> quantisation and inference.
+DGX Spark hardware with an NVIDIA GPU is required for GPU-accelerated
+quantisation and inference.
 
 ## References
 

--- a/playbooks/openshell/README.md
+++ b/playbooks/openshell/README.md
@@ -1,4 +1,4 @@
-# OpenShell Playbook
+# OpenShell playbook
 
 Secure long-running AI agents with OpenShell on DGX Spark. This playbook
 deploys [OpenClaw](https://docs.openclaw.ai/) inside an

--- a/playbooks/pytorch-finetune-nix/README.md
+++ b/playbooks/pytorch-finetune-nix/README.md
@@ -1,6 +1,6 @@
-# PyTorch Fine-tuning (Nix) Playbook
+# PyTorch fine-tuning (Nix) playbook
 
-Fine-tune LLMs using native PyTorch and HuggingFace PEFT on the DGX Spark, with all dependencies provided by Nix.
+Fine-tune LLMs using native PyTorch and HuggingFace PEFT on the DGX Spark. Nix provides all dependencies.
 
 ## Usage
 
@@ -23,7 +23,7 @@ python Llama3_8B_LoRA_finetuning.py
 - BitsAndBytes for 4-bit/8-bit quantisation (QLoRA)
 - NVIDIA fine-tuning scripts from [dgx-spark-playbooks](https://github.com/NVIDIA/dgx-spark-playbooks)
 
-### Available Training Scripts
+### Available training scripts
 
 | Script                           | Description                        |
 | -------------------------------- | ---------------------------------- |
@@ -32,7 +32,7 @@ python Llama3_8B_LoRA_finetuning.py
 | `Llama3_70B_LoRA_finetuning.py`  | LoRA fine-tuning of Llama 3.1 70B  |
 | `Llama3_70B_qLoRA_finetuning.py` | QLoRA fine-tuning of Llama 3.1 70B |
 
-> **Note:** DGX Spark hardware with NVIDIA GPU is required for training.
+DGX Spark hardware with an NVIDIA GPU is required for training.
 
 ## References
 

--- a/playbooks/pytorch-finetune/README.md
+++ b/playbooks/pytorch-finetune/README.md
@@ -1,4 +1,4 @@
-# Fine-tune with PyTorch Playbook
+# Fine-tune with PyTorch playbook
 
 Fine-tune LLMs using native PyTorch and HuggingFace PEFT on the DGX Spark.
 
@@ -16,12 +16,12 @@ pytorch-finetune
 - HuggingFace model cache persisted via volume mount
 - TorchRun for distributed training
 
-### Volume Mounts
+### Volume mounts
 
 - `$PWD` → `/workspace` (training data and scripts)
 - `$HOME/.cache/huggingface` → `/root/.cache/huggingface` (model cache)
 
-> **Note:** DGX Spark hardware with NVIDIA GPU is required for training.
+DGX Spark hardware with an NVIDIA GPU is required for training.
 
 ## References
 

--- a/playbooks/speculative-decoding/README.md
+++ b/playbooks/speculative-decoding/README.md
@@ -1,8 +1,8 @@
-# Speculative Decoding Playbook
+# Speculative decoding playbook
 
 Speculative decoding uses a small draft model to accelerate inference of a
-larger target model on the DGX Spark GPU. This playbook provides two methods
-using TensorRT-LLM.
+larger target model on the DGX Spark GPU. Two methods are available, both
+based on TensorRT-LLM.
 
 ## Prerequisites
 
@@ -54,14 +54,14 @@ verifies in parallel.
 - **Target model:** `nvidia/Llama-3.3-70B-Instruct-FP4`
 - **Draft model:** `nvidia/Llama-3.1-8B-Instruct-FP4`
 
-## How It Works
+## How it works
 
 1. A small **draft model** generates candidate tokens quickly
 2. The large **target model** verifies the candidates in parallel
 3. Accepted tokens are returned, rejected tokens are regenerated
 4. Results in 2-3x faster inference with identical output quality
 
-## Available Commands
+## Available commands
 
 All commands are available inside `nix develop .#speculative-decoding`:
 

--- a/playbooks/trt-llm/README.md
+++ b/playbooks/trt-llm/README.md
@@ -1,7 +1,7 @@
-# TRT-LLM for Inference Playbook
+# TRT-LLM for inference playbook
 
-NVIDIA TensorRT-LLM provides highly optimised LLM inference with kernel
-fusion and quantisation on the DGX Spark.
+NVIDIA TensorRT-LLM provides optimised LLM inference with kernel fusion
+and quantisation on the DGX Spark.
 
 ## Prerequisites
 
@@ -35,14 +35,14 @@ fusion and quantisation on the DGX Spark.
    trt-llm-test "What is the capital of France?"
    ```
 
-## Available Commands
+## Available commands
 
 - `trt-llm-validate` - Verify the TensorRT-LLM container and GPU access
 - `trt-llm-quickstart [MODEL]` - Run a quick inference test without starting a server
 - `trt-llm-serve [MODEL]` - Start an OpenAI-compatible API server (port 8355)
 - `trt-llm-test [PROMPT]` - Send a chat completion request to the running server
 
-## Default Model
+## Default model
 
 The default model is `nvidia/Llama-3.1-8B-Instruct-FP4`, an FP4-quantised
 Llama 3.1 8B model optimised for TensorRT-LLM inference.

--- a/playbooks/vllm-container/README.md
+++ b/playbooks/vllm-container/README.md
@@ -1,6 +1,6 @@
-# vLLM Container Playbook
+# vLLM container playbook
 
-This playbook provides a Nix devshell for running NVIDIA's vLLM inference server for the Qwen2.5-Math-1.5B-Instruct model.
+Run NVIDIA's vLLM inference server for Qwen2.5-Math-1.5B-Instruct via a Nix devshell.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ This playbook provides a Nix devshell for running NVIDIA's vLLM inference server
    vllm-test-math "12*17"
    ```
 
-## Available Commands
+## Available commands
 
 - `vllm-serve-qwen-math` - Start the vLLM server with the Qwen2.5-Math-1.5B-Instruct model
 - `vllm-test-math <query>` - Test the model with a math query (defaults to "12\*17")

--- a/playbooks/vllm-nix/README.md
+++ b/playbooks/vllm-nix/README.md
@@ -1,6 +1,6 @@
-# vLLM Nix Playbook
+# vLLM Nix playbook
 
-This playbook provides a Nix devshell for running vLLM inference server directly from nixpkgs (no containers) for the Qwen2.5-Math-1.5B-Instruct model.
+Run the vLLM inference server directly from nixpkgs (no containers) for Qwen2.5-Math-1.5B-Instruct.
 
 ## Quick Start
 
@@ -22,12 +22,12 @@ This playbook provides a Nix devshell for running vLLM inference server directly
    vllm-test-math "12*17"
    ```
 
-## Available Commands
+## Available commands
 
 - `vllm-serve-qwen-math` - Start the vLLM server with the Qwen2.5-Math-1.5B-Instruct model
 - `vllm-test-math <query>` - Test the model with a math query (defaults to "12\*17")
 
-## Differences from Container Version
+## Differences from container version
 
 - Uses vLLM directly from nixpkgs instead of NVIDIA containers
 - No podman/container runtime required


### PR DESCRIPTION
Align with common technical writer best practices.

- [x] Self-review done by human, reverted some us-english changes claude made.

Used the following prompt in claude: (feel free to copy if you want to use it as well) 
Claude itself distilled this for me from different sources, such as the google guides.

---

```md
# Technical Writing Rules

Rules for clear, accurate technical documentation. Apply these when
rewriting content. Every rule has a reason — don't follow
blindly when the context demands otherwise.

## Voice

- **Active voice.** "The server rejects the request" not "the request
  is rejected by the server." Exception: passive is fine when the actor
  is unknown or irrelevant ("the file is created automatically").
- **Second person.** Address the reader as "you." Not "one," "the user,"
  or "we."
- **Present tense.** "This method returns a list" not "this method will
  return a list." Future tense only for things that literally happen later
  in a sequence.
- **Confident.** State facts directly. "This deletes the file" not "this
  should delete the file" or "this will typically delete the file."

## Sentences

- **Short.** If a sentence exceeds 25 words, split it. If it has a
  semicolon and two dependent clauses, it definitely needs splitting.
- **One idea per paragraph.** Two related but distinct ideas get two
  paragraphs.
- **No filler intros.** Start with the content. Cut "it's worth noting
  that," "in order to," "it's important to understand that."
- **No meta-commentary.** Don't describe what the document does ("this
  guide explains"). Just explain the thing.

## Word Choice

- **Plain words.** "Use" not "utilize." "Start" not "initiate." "End"
  not "terminate." "Help" not "facilitate." "Send" not "transmit."
  Technical precision for technical terms; plain language for everything
  else.
- **Consistent terminology.** One term per concept, everywhere. If the
  UI calls it a "workspace," the docs call it a "workspace." Never
  alternate between synonyms for the same thing.
- **No vague quantifiers.** Name the things. "Supports PostgreSQL,
  MySQL, and SQLite" not "supports various databases."
- **No marketing adjectives.** Drop "powerful," "robust," "seamless,"
  "cutting-edge" unless you immediately back them with a specific claim.

## Structure

- **Sentence case for headings.** "Configure the database" not
  "Configure The Database."
- **Headings describe content.** A reader scanning only headings should
  understand the page. "Set up authentication" not "Getting Started."
- **Numbered lists for sequences.** Bulleted lists for non-sequential
  items. Don't number things that have no order.
- **Parallel list items.** If the first item starts with a verb, all
  items start with a verb. If items are complete sentences, end with
  periods.
- **Minimal callouts.** Two to three per page maximum. If everything is
  a warning, nothing is.

## Code and Examples

- **Show, don't tell.** A code example often replaces an entire
  paragraph of description. When both exist, the example comes first.
- **Examples must work.** Include imports, initialization, and error
  handling when necessary for the code to run. Use realistic values
  (`user@example.com`, not `foo`).
- **Code font for code.** File paths, commands, parameter names, and
  variable names go in backticks. UI elements go in bold.

## What Not to Do

- Don't swap one word for another ("leverage" → "utilize").
- Don't delete content to satisfy a lint rule. Rewrite to be specific.
- Don't remove bold from terms that serve as definitions or labels.
- Don't drop conjunctions or break grammar to shorten sentences.
- Don't add enthusiasm. No exclamation marks in technical prose.

## Sources

Distilled from:

- [Google Developer Documentation Style Guide](https://developers.google.com/style) (CC BY 4.0)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/)
- [Diataxis](https://diataxis.fr/) (CC BY-SA 4.0)
- [developer-docs-framework](https://github.com/anivar/developer-docs-framework) (MIT)

```