### PR TITLE
Drop Firefox in favour of GNOME's bundled Epiphany

### DIFF
--- a/templates/dgx-spark/configuration.nix
+++ b/templates/dgx-spark/configuration.nix
@@ -72,9 +72,6 @@
     options = "--delete-older-than 30d";
   };
 
-  # Enable Firefox web browser
-  programs.firefox.enable = true;
-
   # Enable Zsh (optional)
   # programs.zsh.enable = true;
 

--- a/usb-configuration-base.nix
+++ b/usb-configuration-base.nix
@@ -44,17 +44,6 @@
     efiInstallAsRemovable = true;
   };
 
-  # onnxruntime (pulled in by Firefox's optional ML features) drags in
-  # cudnn-frontend and other CUDA-only packages that hit a
-  # FindCUDAToolkit-can't-find-nvcc bug on aarch64 / CMake 4.3. Firefox is
-  # the only consumer in this image, so disable CUDA in onnxruntime to
-  # sidestep the whole toolchain path.
-  nixpkgs.overlays = [
-    (final: prev: {
-      onnxruntime = prev.onnxruntime.override { cudaSupport = false; };
-    })
-  ];
-
   # File systems configuration handled automatically by ISO image
 
   # Networking
@@ -109,8 +98,8 @@
     pciutils
     usbutils
 
-    # GUI applications for live environment
-    firefox
+    # GUI applications for live environment (GNOME core apps already
+    # provide a browser, Epiphany)
     gnome-terminal
     nautilus
     gnome-text-editor


### PR DESCRIPTION
Firefox is a heavyweight build with a large dependency tree. Both configurations that shipped it (the USB image and the dgx-spark template) already enable GNOME, whose core apps include the Epiphany browser — verified against the pinned nixpkgs (`services.gnome.core-apps.enable` defaults to true and includes `pkgs.epiphany`).

Removing Firefox also lets the USB image delete the onnxruntime CUDA-disable overlay, whose only consumer was Firefox's optional ML features. That removes an overridden (never-cached) onnxruntime build from the image closure.

A smaller closure also shrinks the squashfs the ISO build has to compress, which should help with the OutOfMemory failures the ISO derivation has been hitting on nixbuild.net.

Follow-up: once this merges, the `programs.firefox.enable = lib.mkForce false` workaround in #161's boot VM test becomes redundant and can be dropped when that branch is rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)