### PR TITLE
usb-image: hint nixbuild.net to allocate at least 16 GB for the ISO

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -255,28 +255,38 @@
             let
               targetSystem = "aarch64-linux";
             in
-            (nixpkgs.lib.nixosSystem {
-              system = targetSystem;
-              modules = [
-                ./usb-configuration.nix
-                (
-                  { modulesPath, ... }:
-                  {
-                    imports = [ "${modulesPath}/installer/cd-dvd/iso-image.nix" ];
-                    isoImage.makeEfiBootable = true;
-                    isoImage.makeUsbBootable = true;
-                  }
-                )
-                (
-                  { lib, ... }:
-                  {
-                    nixpkgs.buildPlatform = lib.mkIf (system != targetSystem) {
-                      system = system;
-                    };
-                  }
-                )
-              ];
-            }).config.system.build.isoImage;
+            (
+              (nixpkgs.lib.nixosSystem {
+                system = targetSystem;
+                modules = [
+                  ./usb-configuration.nix
+                  (
+                    { modulesPath, ... }:
+                    {
+                      imports = [ "${modulesPath}/installer/cd-dvd/iso-image.nix" ];
+                      isoImage.makeEfiBootable = true;
+                      isoImage.makeUsbBootable = true;
+                    }
+                  )
+                  (
+                    { lib, ... }:
+                    {
+                      nixpkgs.buildPlatform = lib.mkIf (system != targetSystem) {
+                        system = system;
+                      };
+                    }
+                  )
+                ];
+              }).config.system.build.isoImage
+            ).overrideAttrs {
+              # Squashing the multi-GB closure needs more than the 7 GB a
+              # fresh 2-CPU nixbuild.net allocation provides; each nixpkgs
+              # bump mints a new drv with no build history, so without this
+              # hint every bump wastes ~30 min on an OutOfMemory attempt
+              # before the auto-retry succeeds. Requires the account setting
+              # settings-from-drv-env to be enabled. Harmless elsewhere.
+              NIXBUILDNET_MIN_MEM = "16000";
+            };
 
           packages.default = self.packages.${system}.usb-image;
         };


### PR DESCRIPTION
Removing Firefox (#162) shrank the closure but did **not** cure the ISO OutOfMemory on nixbuild.net: the Firefox-free ISO still died at the default 2-CPU/7 GB allocation (after 28 minutes) before succeeding on the automatic 4-CPU retry. Since every nixpkgs bump mints a new ISO derivation with no build history, each weekly update PR would repeat that ~30-minute wasted attempt.

This adds `NIXBUILDNET_MIN_MEM = "16000"` to the ISO derivation via `overrideAttrs` — nixbuild.net's per-derivation settings mechanism ([docs](https://docs.nixbuild.net/settings/#settings-from-drv-env)). I have enabled the corresponding account-level `settings-from-drv-env` setting. The variable is inert for any other builder.

Sizing: the failed attempt had 7 GB; the successful retry had 14 GB. 16 GB gives headroom without over-allocating.

Note: the env var changes the drv hash, so the next full-build rebuilds the ISO once (with the hint active — labelling this PR `full-build` would prove it end-to-end, at the cost of one ~15 min ISO build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)