### PR TITLE
dgx-spark: add a kernelPageSize option for 64K-page kernels

### DIFF
--- a/kernel-configs/page-size-64k.nix
+++ b/kernel-configs/page-size-64k.nix
@@ -1,0 +1,47 @@
+# 64K-page overrides for the NVIDIA DGX kernel.
+#
+# NVIDIA ships two arm64 flavours in NV-Kernels: `arm64-nvidia` (inheriting
+# `arm64-generic`, 4K pages) and `arm64-nvidia-64k` (inheriting
+# `arm64-generic-64k`, 64K pages). The generated terse config in
+# `nvidia-dgx-spark-<version>.nix` is exported for the 4K flavour, so these
+# are the deltas that turn it into the 64K one.
+#
+# The values come from the `arm64-generic-64k` column of
+# `debian.master/config/annotations` in the NV-Kernels tree -- the nvidia
+# annotations file itself carries no page-size overrides, so the flavour
+# defaults stand. Only the symbols that are a genuine Kconfig choice are
+# listed here: `PAGE_SHIFT`, `PAGE_SIZE_64KB`, `HAVE_PAGE_SIZE_64KB`,
+# `THP_SWAP`, `ARCH_WANT_HUGE_PMD_SHARE` and the AArch32 emulation symbols
+# (`ARMV8_DEPRECATED`, `SWP_EMULATION`, ...) are all selected or derived, so
+# kconfig resolves them from the choices below.
+#
+# Re-check this list against the annotations file when bumping the NVIDIA
+# kernel: `grep generic-64k debian.master/config/annotations`.
+{ lib }:
+
+with lib.kernel;
+
+{
+  # The page-size choice itself. ARM64_16K_PAGES is already `no` in the
+  # generated config, so it needs no override here.
+  ARM64_4K_PAGES = lib.mkForce no;
+  ARM64_64K_PAGES = lib.mkForce yes;
+
+  # 64K granule reaches 48-bit VA in three levels rather than four.
+  # ARM64_VA_BITS stays at 48.
+  PGTABLE_LEVELS = lib.mkForce (freeform "3");
+
+  # Contiguous-PTE/PMD block sizes are granule-dependent.
+  ARM64_CONT_PMD_SHIFT = lib.mkForce (freeform "5");
+  ARM64_CONT_PTE_SHIFT = lib.mkForce (freeform "5");
+
+  # AArch32 userspace is not supported on a 64K-granule kernel; the 32-bit
+  # emulation and compat symbols fall out with it.
+  COMPAT = lib.mkForce no;
+  COMPAT_32BIT_TIME = lib.mkForce no;
+
+  # mmap randomisation is bounded by the page size: the larger granule leaves
+  # fewer bits to randomise. ARCH_MMAP_RND_COMPAT_BITS goes away with COMPAT.
+  ARCH_MMAP_RND_BITS = lib.mkForce (freeform "29");
+  ARCH_MMAP_RND_COMPAT_BITS = lib.mkForce unset;
+}

--- a/modules/dgx-spark.nix
+++ b/modules/dgx-spark.nix
@@ -18,6 +18,8 @@ let
     )
     { inherit lib; };
 
+  pageSize64kConfig = import ../kernel-configs/page-size-64k.nix { inherit lib; };
+
   nvidiaKernelPatches = [
     {
       name = "rust-gendwarfksyms-fix";
@@ -25,7 +27,14 @@ let
     }
   ];
 
-  rawNvidiaKernel = pkgs.linuxPackagesFor (
+  # NVIDIA ships the DGX kernel in two arm64 flavours, 4K- and 64K-page. Build
+  # the selected one: the page size is a compile-time property of the kernel
+  # image, so the two flavours are separate kernel packages rather than a knob
+  # on a shared one (matching how nixos-apple-silicon bakes ARM64_16K_PAGES
+  # into `linux-asahi`, and how NVIDIA builds `arm64-nvidia` vs
+  # `arm64-nvidia-64k`). The `//` ordering matters: the 64K deltas replace the
+  # 4K values the generated config force-sets for PGTABLE_LEVELS and friends.
+  mkNvidiaKernel = pageSize: pkgs.linuxPackagesFor (
     baseKernel.override {
       argsOverride = {
         src = kernelSource.mkNvidiaKernelSource pkgs;
@@ -50,9 +59,12 @@ let
           UEVENT_HELPER = no;
 
           UBUNTU_HOST = no;
-        });
+        })
+        // lib.optionalAttrs (pageSize == "64k") pageSize64kConfig;
     }
   );
+
+  rawNvidiaKernel = mkNvidiaKernel cfg.kernelPageSize;
 
   # Strip embedded references to the kernel `-dev` output from .ko files. The
   # nvidia kernel-modules build (nixpkgs PR #498612) declares
@@ -90,6 +102,30 @@ in
       description = "Whether to use the NVIDIA kernel instead of the standard NixOS kernel";
     };
 
+    kernelPageSize = mkOption {
+      type = types.enum [ "4k" "64k" ];
+      default = "4k";
+      description = ''
+        Page size of the NVIDIA kernel, matching NVIDIA's `arm64-nvidia` and
+        `arm64-nvidia-64k` flavours. The default of 4K matches the stock
+        `arm64-nvidia` flavour and every other aarch64 kernel in nixpkgs.
+
+        64K pages cut TLB pressure and page-table walk depth (three levels
+        rather than four), which can help large-footprint GPU workloads, at
+        the cost of more memory wasted to internal fragmentation and no
+        AArch32 userspace. Note that a 64K-page kernel refuses to load ELF
+        binaries linked with 4K max-page-size alignment; the aarch64 toolchain
+        defaults to 64K so nixpkgs-built code is fine, but vendored binaries
+        (CUDA redistributables, prebuilt wheels) are worth checking.
+
+        Changing this rebuilds the kernel and all out-of-tree modules from
+        source -- there is no cached build for either flavour.
+
+        Requires the NVIDIA kernel (`useNvidiaKernel = true`); the stock NixOS
+        kernel is always 4K.
+      '';
+    };
+
     cppcAutonomousMode = mkOption {
       type = types.bool;
       default = true;
@@ -110,6 +146,19 @@ in
   };
 
   config = mkIf cfg.enable {
+    # The page size is set via the NVIDIA kernel's structuredExtraConfig, so
+    # it is silently ignored on the stock NixOS kernel path.
+    assertions = [
+      {
+        assertion = cfg.kernelPageSize == "64k" -> cfg.useNvidiaKernel;
+        message = ''
+          hardware.dgx-spark.kernelPageSize = "64k" requires
+          hardware.dgx-spark.useNvidiaKernel = true; the stock NixOS kernel is
+          always built with 4K pages.
+        '';
+      }
+    ];
+
     # Add the Flox binary cache as a substituter for pre-built CUDA packages.
     # Flox is authorized by NVIDIA to redistribute CUDA binaries, so packages
     # like cudatoolkit, nccl, cuDNN, torch, etc. can be fetched as pre-built


### PR DESCRIPTION
**Work in progress — parked for now, not ready to merge.** Opening as a draft so the work so far is preserved.

## What this does

Adds `hardware.dgx-spark.kernelPageSize` (`types.enum [ "4k" "64k" ]`, default `4k`), selecting between NVIDIA's two arm64 kernel flavours: `arm64-nvidia` (inheriting `arm64-generic`, 4K pages) and `arm64-nvidia-64k` (inheriting `arm64-generic-64k`, 64K pages). We previously only ever built the 4K one.

Page size is a compile-time property of the kernel image, so the two flavours become two kernel packages rather than a knob on a shared one. `rawNvidiaKernel` becomes `mkNvidiaKernel = pageSize: ...`, appending the 64K deltas to `structuredExtraConfig`; the `//` ordering is what lets them replace the 4K values the generated config force-sets for `PGTABLE_LEVELS` and friends.

## Where the config values come from

`kernel-configs/page-size-64k.nix` holds the eight symbols that genuinely differ, taken from the `arm64-generic-64k` column of `debian.master/config/annotations` in the NV-Kernels tree at the rev we pin. The nvidia-specific annotations file carries no page-size overrides of its own, so the flavour defaults stand. Everything else (`PAGE_SHIFT`, `PAGE_SIZE_64KB`, `THP_SWAP`, `ARCH_WANT_HUGE_PMD_SHARE`, the AArch32 emulation symbols) is selected or derived, so kconfig resolves it from those choices.

## Design note

nixpkgs has no page-size option anywhere — zero references to `ARM64_{4K,16K,64K}_PAGES` in the entire tree. The two precedents are nixpkgs hardcoding the PPC choice in `common-config.nix` ("avoid driver/FS trouble arising from unusual page size") and nixos-apple-silicon baking `ARM64_16K_PAGES` into the `linux-asahi` package. So an option here is a deliberate departure from upstream practice, justified by NVIDIA shipping both flavours for this hardware — but it does mean two full kernel builds to keep warm in any cache rather than one.

## Verified so far

- The 4K kernel derivation is byte-identical to `main` (`pxywgyqpq6w4j0dkywfl2kqc11w0kr15`), so this is a no-op for existing users.
- The resolved 64K config matches the upstream flavour exactly: `PAGE_SHIFT=16`, `PAGE_SIZE_64KB=y`, `PGTABLE_LEVELS=3`, `ARM64_VA_BITS=48`, `ARM64_64K_PAGES=y` with 4K/16K unset, `COMPAT` off, `ARCH_MMAP_RND_BITS=29`, `ARM64_CONT_{PTE,PMD}_SHIFT=5`.
- The 64K kernel builds (`Image`, `System.map`, `dtbs`).
- Pre-commit hooks pass.

## Still to do before this is mergeable

- [ ] Build the NVIDIA out-of-tree modules against the 64K kernel — the most likely place for a page-size problem to surface, and untested so far.
- [ ] Boot it and confirm `getconf PAGESIZE` returns 65536.
- [ ] Check vendored binaries load: a 64K-page kernel refuses ELFs linked with 4K max-page-size alignment. The aarch64 toolchain defaults to 64K so nixpkgs-built code should be fine, but the flox CUDA redistributables and any prebuilt wheels are worth verifying.
- [ ] Decide whether an eval check in `checks/` should cover the option wiring and the assertion.
- [ ] Benchmark whether 64K actually helps the GPU workloads before recommending it to anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)