### PR TITLE
ci: skip nixbuild jobs on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,13 @@ jobs:
       - name: Evaluate the full dgx-spark configuration
         run: nix eval --raw .#nixosConfigurations.dgx-spark.config.system.build.toplevel.drvPath
 
+  # Dependabot-triggered runs read from the Dependabot secrets store, not the
+  # Actions one, so secrets.NIXBUILD_TOKEN is empty and nixbuild-action fails
+  # immediately. Skip rather than report a red build nobody can act on; the
+  # 'check' job still runs, and the post-merge push to main does the real
+  # build with the token in scope.
   build:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     steps:
@@ -99,8 +105,9 @@ jobs:
   # multi-GB closure off the runner; outputs stay on nixbuild.net.
   full-build:
     if: >
-      (github.event_name == 'workflow_dispatch' && inputs.full_build) ||
-      contains(github.event.pull_request.labels.*.name, 'full-build')
+      github.actor != 'dependabot[bot]' &&
+      ((github.event_name == 'workflow_dispatch' && inputs.full_build) ||
+      contains(github.event.pull_request.labels.*.name, 'full-build'))
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 240
     steps:


### PR DESCRIPTION
## Problem

The `build` job fails within seconds on dependabot PRs (e.g. #166, bumping nixbuild-action v25 → v26). The nixbuild-action step is invoked with an empty token:

```
nixbuild-action.sh {"NIXBUILD_TOKEN":"", ...}
```

Dependabot-triggered workflow runs resolve `secrets.*` from the **Dependabot** secrets store, not the Actions one. `NIXBUILD_TOKEN` exists only in the latter, so the action gets an empty string and exits 1.

This is not a v26 regression — v25 fails identically under a dependabot actor. It had simply never been exercised: the previous dependabot PR (#146, June) predates the `build` job, when CI was `check`-only.

## Change

Guard both nixbuild-dependent jobs on the actor:

- `build` — new `if: github.actor != 'dependabot[bot]'`
- `full-build` — the same condition ANDed onto its existing label/dispatch gate. Label-gating made this unlikely to fire on a dependabot PR, but a `full-build` label on one would have hit the identical failure.

`check` still runs on dependabot PRs (cachix-action tolerates an empty token), and the post-merge push to `main` performs the real build with the token in scope.

## Alternative considered

Mirroring `NIXBUILD_TOKEN` into the Dependabot secrets store would restore full CI, but on an *action*-bump PR the job would run the newly-bumped action with the nixbuild token in scope — precisely the supply-chain surface Dependabot's secret isolation exists to close. Skipping trades unvalidated bumps for keeping that isolation.

## Follow-up

#166 runs its workflow from its own merge ref, so it needs a rebase (or close/reopen) after this lands before its `build` job disappears — or just merge it directly, since the diff is two version strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)