### PR TITLE
ci: build the playbook devShell closures, and fix comfyui

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       full_build:
-        description: "Also build usb-image on nixbuild.net"
+        description: "Also build usb-image and the playbook devShells on nixbuild.net"
         type: boolean
         default: false
 
@@ -99,17 +99,19 @@ jobs:
           nix build -L --no-link --max-jobs 1 --builders "" \
             .#checks.aarch64-linux.dgx-dashboard-vm
 
-  # Expensive: builds the USB image (including the custom kernel) entirely
-  # on nixbuild.net. Runs only for PRs labelled 'full-build' or manual
-  # dispatch with full_build enabled. Remote-store building keeps the
-  # multi-GB closure off the runner; outputs stay on nixbuild.net.
+  # Expensive: builds the USB image (including the custom kernel) and the
+  # build closure of every playbook devShell (including CUDA torch and
+  # vllm) entirely on nixbuild.net. Runs only for PRs labelled
+  # 'full-build' or manual dispatch with full_build enabled. Remote-store
+  # building keeps the multi-GB closure off the runner; outputs stay on
+  # nixbuild.net.
   full-build:
     if: >
       github.actor != 'dependabot[bot]' &&
       ((github.event_name == 'workflow_dispatch' && inputs.full_build) ||
       contains(github.event.pull_request.labels.*.name, 'full-build'))
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 240
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v7
 
@@ -156,3 +158,16 @@ jobs:
         run: |
           nix build -L --no-link --max-jobs 1 --builders "" \
             .#checks.aarch64-linux.dgx-spark-boot-vm
+
+      # devshell-closures aggregates every devShell's .inputDerivation
+      # (plus a weights-free comfyui), so this proves the playbooks still
+      # build rather than merely still evaluate. Runs last and with
+      # --keep-going: it is the longest step by far, and one broken
+      # playbook should not hide the state of the others.
+      - name: Build playbook devShell closures on nixbuild.net
+        run: |
+          nix build -L --no-link --keep-going \
+            --store ssh-ng://eu.nixbuild.net \
+            --eval-store auto \
+            --builders "" --max-jobs 2 \
+            .#devshell-closures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ If you get "No .pre-commit-config.yaml file was found" when committing, run `nix
 
 Each playbook lives in `playbooks/<name>/` with `shell.nix` and `README.md`. Register it in `flake.nix` under the aarch64-linux block as `devShells.<name> = pkgs.callPackage ./playbooks/<name>/shell.nix { inherit nixglhost; };`. Also add a row to the playbook table in the top-level `README.md`.
 
+No CI change is needed: `packages.devshell-closures` is derived from `config.devShells`, so registering the shell also enrols it in the label-gated `full-build` job.
+
 When writing the shell.nix:
 
 - Use `pkgs.python3Packages.<package>` (not `python3xxPackages`). Focus on Python 3.12+; ignore older versions.
@@ -38,6 +40,7 @@ When writing the shell.nix:
 ## CI and automated updates
 
 - The weekly flake.lock update PRs are opened with a PAT (`FLAKE_UPDATE_TOKEN`) precisely so CI runs on them, and the update workflow automatically posts an `@claude` brief on each one: fix CI failures first, then audit local workarounds/TODOs (overlays/fixes.nix, patches/, pins, disabled tests) for ones made obsolete by the bump. Commenting `@claude` on any issue or PR also triggers the Claude workflow.
+- The label-gated `full-build` job covers the usb-image, the boot VM test, and `packages.devshell-closures` (every devShell's build inputs, plus a weights-free comfyui). It is the only job that builds CUDA torch and vllm.
 - The Claude workflow runs on an ARM runner with nix installed and nixbuild.net configured as a remote builder (plain `nix build` dispatches remotely), plus the cachix/flox caches. Agent runs must never build expensive outputs (usb-image, the kernel, vllm, CUDA devShells) -- CI's label-gated full-build job covers the kernel.
 - Pushes made by the Claude workflow use the default `GITHUB_TOKEN`, which does **not** re-trigger CI. To get a fresh CI run on such a PR, close and reopen it, or push an empty commit.
 

--- a/flake.nix
+++ b/flake.nix
@@ -212,6 +212,31 @@
             openshell = pkgs.callPackage ./packages/openshell { };
           };
 
+          # Aggregate of every devShell's build closure, so CI can prove the
+          # playbooks still build rather than merely still evaluate. mkShell
+          # derivations are not themselves buildable, hence .inputDerivation.
+          # Derived from config.devShells, so a newly registered playbook is
+          # covered automatically.
+          #
+          # comfyui is special-cased: its devShell pins withModels =
+          # [ comfyuiModels.sd15-fp16 ], a ~2 GB weights fetch that is pure
+          # bandwidth in CI. The unoverridden package has the same code
+          # closure minus the weights, so it is built instead.
+          packages.devshell-closures = pkgs.linkFarm "devshell-closures" (
+            nixpkgs.lib.mapAttrsToList
+              (name: shell: {
+                inherit name;
+                path = shell.inputDerivation;
+              })
+              (removeAttrs config.devShells [ "comfyui" ])
+            ++ [
+              {
+                name = "comfyui";
+                path = pkgs.comfyuiPackages.comfyui;
+              }
+            ]
+          );
+
           packages.cuda-debug = pkgs.callPackage ./packages/cuda-debug { };
           packages.dgx-dashboard = pkgs.callPackage ./packages/dgx-dashboard { };
           packages.openshell = pkgs.callPackage ./packages/openshell { };

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
       linux617Overlay = import ./overlays/linux-6.17.nix;
       fixesOverlay = import ./overlays/fixes.nix;
       comfyuiModelsOverlay = import ./overlays/comfyui-models.nix;
+      nixifiedAiFixesOverlay = import ./overlays/nixified-ai-fixes.nix;
     in
     flake-parts.lib.mkFlake { inherit inputs; } {
       flake = {
@@ -62,7 +63,7 @@
       };
       systems = [ "aarch64-linux" ];
       perSystem =
-        { system, ... }:
+        { config, system, ... }:
         let
           commonConfig = {
             allowUnfree = true;
@@ -81,6 +82,7 @@
               nixified-ai.overlays.models
               nixified-ai.overlays.fetchers
               comfyuiModelsOverlay
+              nixifiedAiFixesOverlay
             ];
           };
 

--- a/overlays/nixified-ai-fixes.nix
+++ b/overlays/nixified-ai-fixes.nix
@@ -1,0 +1,26 @@
+# Fixes for the nixified-ai overlays' python3Packages scope.
+#
+# Must be applied *after* nixified-ai.overlays.comfyui, which extends the
+# set with python3Packages.overrideScope -- an override in fixes.nix (which
+# runs earlier) would just be clobbered.
+final: prev: {
+  python3Packages = prev.python3Packages.overrideScope (
+    _: pyprev: {
+      # nixified-ai patches transformers to make the flash_attn lookup in
+      # import_utils.py tolerant of a missing distribution, but transformers
+      # 5.15.0 already does exactly that upstream (import_utils.py lines
+      # 1176/1234/1245 all read .get("flash_attn", [])). The patch's
+      # --replace-fail therefore aborts the build, breaking comfyui.
+      #
+      # Relax just that one call to --replace-quiet: a no-op while upstream
+      # carries the fix, and still correct if nixified-ai's patch becomes
+      # load-bearing again. Drop this once nixified-ai removes the patch.
+      transformers = pyprev.transformers.overridePythonAttrs (old: {
+        postPatch = builtins.replaceStrings
+          [ "--replace-fail 'PACKAGE_DISTRIBUTION_MAPPING[\"flash_attn\"]'" ]
+          [ "--replace-quiet 'PACKAGE_DISTRIBUTION_MAPPING[\"flash_attn\"]'" ]
+          (old.postPatch or "");
+      });
+    }
+  );
+}


### PR DESCRIPTION
## What

Adds `packages.devshell-closures` to the label-gated `full-build` job, so CI builds every playbook devShell rather than merely evaluating it — and fixes the first breakage that found.

Previously `full-build` covered only the usb-image and the boot VM test. Nothing in CI built a devShell, so **vllm and CUDA torch were never compiled by CI at all**: `checks/vllm-units.nix` deliberately stubs vllm (and discards its string context), and the `check` job is evaluation-only. A playbook could break at build time and stay green.

## How

`packages.devshell-closures` link-farms each devShell's `.inputDerivation` (an `mkShell` derivation is not itself buildable). It is derived from `config.devShells`, so registering a new playbook enrols it automatically — no CI change per playbook.

comfyui is special-cased. Its devShell pins `withModels = [ comfyuiModels.sd15-fp16 ]`, a ~2 GB weights fetch that is pure bandwidth in CI, so the unoverridden package is built instead — same code closure, no weights. Confirmed by counting `v1-5-pruned` references in the recursive derivation graph: 1 with the override, 0 without.

## The comfyui fix

The local verification run immediately found that **`comfyuiPackages.comfyui` was already broken on `main`**, silently, because nothing built it.

nixified-ai patches transformers so the `flash_attn` lookup in `import_utils.py` tolerates a missing distribution, but transformers 5.15.0 already does exactly that upstream (`import_utils.py` lines 1176/1234/1245 all read `.get("flash_attn", [])`). Its `--replace-fail` therefore aborts `patchPhase`.

Fixed by relaxing that one call to `--replace-quiet` in a new overlay applied *after* nixified-ai's — it extends the set via `python3Packages.overrideScope`, so an override in `overlays/fixes.nix` (which runs earlier) would be clobbered. Worth dropping once nixified-ai removes the patch.

## Verification

Full local build on the Spark, `nix build --keep-going --builders "" .#devshell-closures` → **exit 0, zero failures**, all 17 shells plus comfyui:

```
comfyui  cuda  default  flux-dreambooth  llama-cpp  multi-agent-chatbot
multimodal-inference  nccl-two-sparks  nvfp4  openshell  pytorch-finetune
pytorch-finetune-nix  speculative-decoding  torch  trt-llm  vllm-container  vllm-nix
```

`nix flake check --no-build` and all pre-commit hooks pass. Timeout raised 240 → 360 min to allow for a cold CUDA torch.

## Note on the python split

Worth recording, since it looks like an obvious cleanup: `pkgs.vllm` follows python **3.13** while everything else here (`pythonEnv`, pytorch-finetune-nix, comfyui) follows the default **3.14**, which means two full CUDA torch closures to build and cache.

That cannot currently be unified on the default interpreter. nixpkgs pinning `pkgs/by-name/vl/vllm/package.nix` to `python313Packages` tracks a hard upstream constraint, not an arbitrary freeze:

```
CMake Error at vllm-flash-attn-2.7.2.post1/cmake/utils.cmake:20 (message):
  Python version (3.14) is not one of the supported versions:
  3.9;3.10;3.11;3.12;3.13.
```

The achievable inverse — pulling everything down to python313 for a single torch closure, with `python3.13-torch-2.12.0` already in cachix — is left for a follow-up, since it trades the default interpreter for a pin needing revisiting when vllm gains 3.14 support.

## Testing

`full-build` is label-gated, so this needs the `full-build` label to actually exercise the new step. The devShell build is the longest step by far, runs last, and uses `--keep-going` so one broken playbook cannot hide the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)