### PR TITLE
modules/dgx-spark: enable ConnectX-7 hotplug support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ This module provides configurable DGX Spark hardware support with options for ke
 hardware.dgx-spark = {
   enable = true;                 # Enable DGX Spark hardware support
   useNvidiaKernel = true;        # Use NVIDIA kernel (default: true)
+  connectx7Hotplug = true;       # Enable ConnectX-7 hot-plug (default: true)
 };
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -239,6 +239,7 @@
 
           packages.cuda-debug = pkgs.callPackage ./packages/cuda-debug { };
           packages.dgx-dashboard = pkgs.callPackage ./packages/dgx-dashboard { };
+          packages.dgx-spark-mlnx-hotplug = pkgs.callPackage ./packages/dgx-spark-mlnx-hotplug { };
           packages.openshell = pkgs.callPackage ./packages/openshell { };
           packages.perftest = pkgs.callPackage ./packages/perftest { };
 

--- a/modules/dgx-spark-connectx7.nix
+++ b/modules/dgx-spark-connectx7.nix
@@ -1,0 +1,42 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+
+let
+  cfg = config.hardware.dgx-spark;
+  kernelSource = import ../kernel-configs/nvidia-kernel-source.nix;
+
+  connectx7HotplugModule = config.boot.kernelPackages.callPackage ../packages/dgx-spark-cx7-hotplug-module {
+    src = kernelSource.mkNvidiaKernelSource pkgs;
+  };
+
+  connectx7Hotplug = pkgs.callPackage ../packages/dgx-spark-mlnx-hotplug { };
+in
+{
+  options.hardware.dgx-spark.connectx7Hotplug = lib.mkOption {
+    type = lib.types.bool;
+    default = true;
+    description = ''
+      Enable ConnectX-7 PCIe hot-plug support using NVIDIA's udev helper
+      and the out-of-tree mtk-pcie-hotplug kernel module.
+    '';
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.connectx7Hotplug) {
+    boot.extraModulePackages = [ connectx7HotplugModule ];
+    boot.kernelModules = [ "mtk-pcie-hotplug" ];
+
+    services.udev.packages = [ connectx7Hotplug ];
+
+    # NVIDIA's Debian package creates this marker in its post-install script.
+    # The helper deliberately leaves hot-plug disabled when the marker is absent.
+    environment.etc."nvidia/cx7-hotplug-enabled" = {
+      text = ''
+        # CX7 Hotplug Configuration
+        # Presence of this file enables ConnectX-7 hot-plug power management.
+      '';
+    };
+  };
+}

--- a/modules/dgx-spark.nix
+++ b/modules/dgx-spark.nix
@@ -78,6 +78,7 @@ in
 {
   imports = [
     ./dgx-dashboard.nix
+    ./dgx-spark-connectx7.nix
     ./vllm.nix
   ];
 

--- a/packages/dgx-spark-cx7-hotplug-module/default.nix
+++ b/packages/dgx-spark-cx7-hotplug-module/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, writeText
+, kernel
+, src
+,
+}:
+
+let
+  kbuildFile = writeText "dgx-spark-cx7-hotplug-kbuild" ''
+    obj-m += mtk-pcie-hotplug.o
+  '';
+in
+stdenv.mkDerivation rec {
+  pname = "dgx-spark-cx7-hotplug-module";
+  version = kernel.modDirVersion;
+
+  inherit src;
+
+  dontUnpack = true;
+  strictDeps = true;
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp "$src/drivers/platform/arm64/nvidia/mtk-pcie-hotplug.c" mtk-pcie-hotplug.c
+    cp "${kbuildFile}" Makefile
+    make -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" \
+      M="$PWD" \
+      modules
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 mtk-pcie-hotplug.ko \
+      "$out/lib/modules/${kernel.modDirVersion}/extra/mtk-pcie-hotplug.ko"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "ConnectX-7 PCIe hotplug kernel module for NVIDIA DGX Spark";
+    homepage = "https://github.com/NVIDIA/NV-Kernels";
+    license = lib.licenses.gpl2Only;
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/packages/dgx-spark-mlnx-hotplug/default.nix
+++ b/packages/dgx-spark-mlnx-hotplug/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, dpkg
+, makeWrapper
+, bash
+, coreutils
+, gnugrep
+, pciutils
+,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "dgx-spark-mlnx-hotplug";
+  version = "26.01-1";
+
+  src = fetchurl {
+    url = "https://repo.download.nvidia.com/baseos/ubuntu/noble/arm64/pool/dgx/d/dgx-spark-mlnx-hotplug/${finalAttrs.pname}_${finalAttrs.version}_all.deb";
+    hash = "sha256-LbHoe6LS56PavyHUbO07N+nTj9pRhDgAWAXb4E39zAE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  buildInputs = [ bash ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb --extract "$src" .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 \
+      opt/nvidia/dgx-spark-mlnx-hotplug/mtk-hotplug-handler.sh \
+      "$out/libexec/dgx-spark-mlnx-hotplug/mtk-hotplug-handler.sh"
+    install -Dm644 \
+      lib/udev/rules.d/90-mtk-hotplug.rules \
+      "$out/lib/udev/rules.d/90-mtk-hotplug.rules"
+    install -Dm644 \
+      usr/share/doc/dgx-spark-mlnx-hotplug/copyright \
+      "$out/share/doc/dgx-spark-mlnx-hotplug/copyright"
+    install -Dm644 \
+      usr/share/doc/dgx-spark-mlnx-hotplug/changelog.Debian.gz \
+      "$out/share/doc/dgx-spark-mlnx-hotplug/changelog.Debian.gz"
+
+    patchShebangs "$out/libexec/dgx-spark-mlnx-hotplug/mtk-hotplug-handler.sh"
+    substituteInPlace "$out/lib/udev/rules.d/90-mtk-hotplug.rules" \
+      --replace-fail \
+        "/opt/nvidia/dgx-spark-mlnx-hotplug/mtk-hotplug-handler.sh" \
+        "$out/libexec/dgx-spark-mlnx-hotplug/mtk-hotplug-handler.sh"
+    wrapProgram "$out/libexec/dgx-spark-mlnx-hotplug/mtk-hotplug-handler.sh" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          pciutils
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "ConnectX-7 hot-plug power management for NVIDIA DGX Spark";
+    homepage = "https://docs.nvidia.com/dgx/dgx-spark/release-notes.html";
+    license = lib.licenses.unfree;
+    platforms = [ "aarch64-linux" ];
+  };
+})


### PR DESCRIPTION
I’ve been running this for over a month without encountering any issues. However, I don’t have a second Spark or a QSFP cable to verify that the module works correctly when the ConnectX-7 interface is connected. I’ve only tested the powered-down behavior and confirmed that it reduces power consumption while disconnected (40W -> 25W).

fixes #165